### PR TITLE
Update Reactant commit and version to 0.0.375

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -7,8 +7,8 @@ include(joinpath(YGGDRASIL_DIR, "platforms", "macos_sdks.jl"))
 
 name = "Reactant"
 repo = "https://github.com/EnzymeAD/Reactant.jl.git"
-reactant_commit = "2ee58dbc667a2d1388720c2b9d5fd19815987cdc"
-version = v"0.0.374"
+reactant_commit = "bbe50a4c62a6190408c857ed447a66800ded1642"
+version = v"0.0.375"
 
 sources = [
    GitSource(repo, reactant_commit),


### PR DESCRIPTION
Points the Reactant_jll build at Reactant.jl main @ `bbe50a4c62a6190408c857ed447a66800ded1642` — that's the most recent merge to `main`, which is PR #2827 "Update EnzymeAD/Enzyme-JAX to commit 81bb7d51954d1f0d66c0434a7c1970c72b3e0d51".

Routine 2-line bump in `R/Reactant/build_tarballs.jl`:

- `reactant_commit`: `2ee58dbc…` → `bbe50a4c…`
- `version`: `0.0.374` → `0.0.375`