### PR TITLE
try fix ROCm build

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -326,7 +326,7 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
     )
     
     # Prevent Clang/hipcc from turning relative symlinks into absolute paths in depfiles
-    BAZEL_BUILD_FLAGS+=(--copt=-no-canonical-prefixes --host_copt=-no-canonical-prefixes)
+    BAZEL_BUILD_FLAGS+=(--copt=-no-canonical-prefixes --cxxopt=-no-canonical-prefixes)
 
     # For GCC/mixed toolchain wrapper edge cases
     # BAZEL_BUILD_FLAGS+=(--copt=-fno-canonical-system-headers --host_copt=-fno-canonical-system-headers)
@@ -419,6 +419,9 @@ elif [[ "${target}" == aarch64-* ]] && [[ "${HERMETIC_CUDA_VERSION}" == *13.* ]]
 elif [[ "${target}" == aarch64-* ]] && [[ "${HERMETIC_CUDA_VERSION}" == *12.* ]]; then
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so || echo stage1
     cp /workspace/srcdir/cuda_nvcc-linux-sbsa*-archive/lib/*.a /workspace/bazel_root/*/external/cuda_nvcc/lib/
+    $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so
+elif [[ "${bb_full_target}" == *rocm* ]]; then
+    $BAZEL ${BAZEL_FLAGS[@]} fetch --enable_bzlmod --configure --force
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so
 else
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -324,6 +324,12 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
 	    --action_env=CLANG_COMPILER_PATH=$(which clang)
 	    --define=using_clang=true
     )
+    
+    # Prevent Clang/hipcc from turning relative symlinks into absolute paths in depfiles
+    BAZEL_BUILD_FLAGS+=(--copt=-no-canonical-prefixes --host_copt=-no-canonical-prefixes)
+
+    # For GCC/mixed toolchain wrapper edge cases
+    BAZEL_BUILD_FLAGS+=(--copt=-fno-canonical-system-headers --host_copt=-fno-canonical-system-headers)
 fi
 
 if [[ "${target}" == *-freebsd* ]]; then

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -324,12 +324,6 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
 	    --action_env=CLANG_COMPILER_PATH=$(which clang)
 	    --define=using_clang=true
     )
-    
-    # Prevent Clang/hipcc from turning relative symlinks into absolute paths in depfiles
-    BAZEL_BUILD_FLAGS+=(--copt=-no-canonical-prefixes --cxxopt=-no-canonical-prefixes)
-
-    # For GCC/mixed toolchain wrapper edge cases
-    # BAZEL_BUILD_FLAGS+=(--copt=-fno-canonical-system-headers --host_copt=-fno-canonical-system-headers)
 fi
 
 if [[ "${target}" == *-freebsd* ]]; then
@@ -419,9 +413,6 @@ elif [[ "${target}" == aarch64-* ]] && [[ "${HERMETIC_CUDA_VERSION}" == *13.* ]]
 elif [[ "${target}" == aarch64-* ]] && [[ "${HERMETIC_CUDA_VERSION}" == *12.* ]]; then
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so || echo stage1
     cp /workspace/srcdir/cuda_nvcc-linux-sbsa*-archive/lib/*.a /workspace/bazel_root/*/external/cuda_nvcc/lib/
-    $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so
-elif [[ "${bb_full_target}" == *rocm* ]]; then
-    $BAZEL ${BAZEL_FLAGS[@]} fetch --enable_bzlmod --configure --force
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so
 else
     $BAZEL ${BAZEL_FLAGS[@]} build ${BAZEL_BUILD_FLAGS[@]} :libReactantExtra.so

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -329,7 +329,7 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
     BAZEL_BUILD_FLAGS+=(--copt=-no-canonical-prefixes --host_copt=-no-canonical-prefixes)
 
     # For GCC/mixed toolchain wrapper edge cases
-    BAZEL_BUILD_FLAGS+=(--copt=-fno-canonical-system-headers --host_copt=-fno-canonical-system-headers)
+    # BAZEL_BUILD_FLAGS+=(--copt=-fno-canonical-system-headers --host_copt=-fno-canonical-system-headers)
 fi
 
 if [[ "${target}" == *-freebsd* ]]; then

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -82,7 +82,7 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
     sed -i -e "s,vrun ,PRE_FLAGS+=( -L$ROCM_PATH/lib ); vrun ,g" `which clang++`
     cp `which clang` $ROCM_PATH/bin/hipcc
     sed -i "s,/opt/x86_64-linux-musl/bin/clang,$ROCM_PATH/bin/hipcc.real,g" $ROCM_PATH/bin/hipcc
-    sed -i -e "s,PRE_FLAGS+=( -nostdinc++,PRE_FLAGS+=( -fuse-cuid=random -nostdinc++ -isystem/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers -isystem/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include,g" $ROCM_PATH/bin/hipcc
+    sed -i -e "s,PRE_FLAGS+=( -nostdinc++,PRE_FLAGS+=( -fuse-cuid=random -nostdinc++ -isystem external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include,g" $ROCM_PATH/bin/hipcc
     sed -i -e "s,export LD_LIBRARY_PATH,POST_FLAGS+=( --rocm-path=$ROCM_PATH -B $ROCM_PATH/lib/llvm/bin); export LD_LIBRARY_PATH,g" $ROCM_PATH/bin/hipcc
     sed -i -e "s,export LD_LIBRARY_PATH,export TMPDIR=/workspace/srcdir/Reactant.jl/deps/ReactantExtra/.tmp; export LD_LIBRARY_PATH,g" $ROCM_PATH/bin/hipcc
     sed -i -e "s,export LD_LIBRARY_PATH,export TMPDIR=/workspace/srcdir/Reactant.jl/deps/ReactantExtra/.tmp; export LD_LIBRARY_PATH,g" /opt/bin/x86_64-linux-musl-cxx11/x86_64-linux-musl-clang


### PR DESCRIPTION
tries to fix the following error https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/26634414443/job/78491490909?pr=2467#step:10:1782

```
ERROR: /workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/xla/xla/stream_executor/rocm/BUILD:1114:14: Compiling xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc failed: absolute path inclusion(s) found in rule '@@xla//xla/stream_executor/rocm:cub_sort_kernel_rocm_type_u64':
[11:35:52] the source file 'xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain):
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_hip_runtime_wrapper.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/cmath'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/bits/c++config.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/stddef.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_size_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_wchar_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_null.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_hip_libdevice_declares.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_hip_math.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/limits.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/stdint.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_hip_stdlib.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_cuda_math_forward_declares.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_hip_cmath.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__clang_cuda_complex_builtins.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/algorithm'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/new'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/complex'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_header_macro.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_ptrdiff_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_nullptr_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_max_align_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_offsetof.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/stdarg.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stdarg___gnuc_va_list.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/__stddef_wint_t.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/bits/basic_string.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/bits/basic_string.tcc'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/cuda_wrappers/bits/shared_ptr_base.h'
[11:35:52]   '/workspace/bazel_root/097636303b1142f44508c1d8e3494e4b/external/local_config_rocm/rocm/rocm_dist/lib/llvm/lib/clang/22/include/sanitizer/tsan_interface.h'
```