### PR TITLE
Add post-build check for unresolved nvcc device-link symbols

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -651,6 +651,30 @@ fi
 
 
 install -Dvm 755 bazel-bin/libReactantExtra.so "${libdir}/libReactantExtra.${dlext}"
+
+# Post-build sanity check for CUDA builds: nvcc's separate-compilation machinery
+# emits registration symbols (`__cudaRegisterLinkedBinary_<module-id>`,
+# `__fatbinwrap_<module-id>`, ...) that are always resolved within the same
+# shared library; no external library provides them. Any such symbol left
+# undefined means host/target CUDA device-link objects got mixed during the
+# build, and the library will fail to dlopen at load time. This shipped in the
+# broken aarch64 CUDA-13.1 builds of v0.0.394-v0.0.396, see
+# https://github.com/EnzymeAD/Reactant.jl/issues/3112
+if [[ "${bb_full_target}" == *gpu+cuda* ]] && [[ "${target}" == *-linux-* ]]; then
+    # separate `readelf -h` run: a readelf failure inside the pipeline below
+    # would be masked by awk succeeding on empty input
+    readelf -h "${libdir}/libReactantExtra.${dlext}" > /dev/null
+    bad_syms=$(readelf -W --dyn-syms "${libdir}/libReactantExtra.${dlext}" |
+               awk '$7 == "UND" && $8 ~ /^(__cuda|__fatbin|__nv_)/ { print $8 }' |
+               sort -u)
+    if [[ -n "${bad_syms}" ]]; then
+        echo "ERROR: unresolvable nvcc device-link symbols in libReactantExtra.${dlext}:" >&2
+        echo "${bad_syms}" >&2
+        echo "The library would fail to dlopen at load time, refusing to package it." >&2
+        exit 1
+    fi
+fi
+
 install_license ../../LICENSE
 """
 

--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -657,9 +657,7 @@ install -Dvm 755 bazel-bin/libReactantExtra.so "${libdir}/libReactantExtra.${dle
 # `__fatbinwrap_<module-id>`, ...) that are always resolved within the same
 # shared library; no external library provides them. Any such symbol left
 # undefined means host/target CUDA device-link objects got mixed during the
-# build, and the library will fail to dlopen at load time. This shipped in the
-# broken aarch64 CUDA-13.1 builds of v0.0.394-v0.0.396, see
-# https://github.com/EnzymeAD/Reactant.jl/issues/3112
+# build, and the library will fail to dlopen at load time.
 if [[ "${bb_full_target}" == *gpu+cuda* ]] && [[ "${target}" == *-linux-* ]]; then
     # separate `readelf -h` run: a readelf failure inside the pipeline below
     # would be masked by awk succeeding on empty input


### PR DESCRIPTION
Related to EnzymeAD/Reactant.jl#3112 doesn't fix it, but adds at guard to detect that kind of problem during build. Fix is beyond my expertise:

PR content generated by Claude Opus-5 max:

## What

After the final `install` of `libReactantExtra.so`, CUDA Linux builds now fail if the library's dynamic symbol table contains an undefined `__cuda*` / `__fatbin*` / `__nv_*` symbol.

nvcc's separate-compilation machinery emits these registration symbols (`__cudaRegisterLinkedBinary_<module-id>`, `__fatbinwrap_<module-id>`, ...) and always resolves them within the same shared library; no external library provides them. One left undefined means mismatched host/target device-link objects, and the library fails to `dlopen` at load time — the EnzymeAD/Reactant.jl#3112 failure mode, which shipped in the aarch64 CUDA-13.1 artifacts of v0.0.394+0 through v0.0.396+0. (Possibly the same module-ID/CUID family as #142.)

## Why a static check

The audit paths that would normally catch an unloadable library don't apply to this recipe:

- `dont_dlopen=true` (GCC 13 workaround) and `skip_audit` on Enzyme-JAX CI runs;
- `dlopen` couldn't inspect cross-built aarch64 artifacts on the x86_64 builder anyway.

`readelf` reads foreign-arch ELF, so the check covers exactly the cross-compiled case that broke.

## Validation against released artifacts

| artifact (Reactant_jll) | dlopen | total UND syms | UND matching check |
|---|---|---|---|
| aarch64 12.9, v0.0.395+1 | OK | 1047 | 0 |
| x86_64 12.9, v0.0.395+1 | n/a (foreign arch) | 1148 | 0 |
| aarch64 13.1, v0.0.395+1 | fails (#3112) | 1070 | 1 — `__cudaRegisterLinkedBinary_…_separate_callback_cu_4817d27c_3513083` |
| aarch64 13.1, v0.0.394+0 | fails | 1068 | 1 — same symbol |

Zero false positives on working builds; fires on exactly the broken ones. The literal script block was also executed standalone (under `set -euo pipefail`) against a working artifact (silent pass), a broken one (error + `exit 1`), and a `gpu+none` target (skipped).

## Scope notes

- Pattern is `__nv_` (with trailing underscore), not `__nv`: the bundled `libnvrtc` legitimately imports `__nvrtc_builtins__*` from `libnvrtc-builtins`, and the tighter prefix keeps that class of symbol out of scope should such a reference ever appear in `libReactantExtra` itself.
- Only `libReactantExtra.${dlext}` is checked — the library this recipe links. The bundled NVIDIA libraries were scanned and are clean, but they are vendor binaries; failing the build over their internals wouldn't be actionable here.
- A separate `readelf -h` runs first so an unreadable file fails the build instead of silently passing the pipeline (`awk` succeeds on empty input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RJr7Diee2Zq3vtQgb5E5C
