### PR TITLE
aarch64: disable ynnpack FP8 kernels, GCC lacks the ARM FP8 ACLE

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -278,6 +278,11 @@ if [[ "${target}" == aarch64-* ]]; then
     BAZEL_BUILD_FLAGS+=(--copt=-march=armv8+aes+sha2)
     BAZEL_BUILD_FLAGS+=(--copt=-DDNNL_ARCH_GENERIC=1)
     BAZEL_BUILD_FLAGS+=(--define=@xla//build_with_mkl_aarch64=true)
+    # ynnpack's FP8 kernels are compiled with -march=...+fp8+fp8dot4 and use
+    # the ARM FP8 ACLE (mfloat8 types, __arm_fpm_init), which GCC only has
+    # from 15 on; our toolchain is older, so leave those kernels out.
+    BAZEL_BUILD_FLAGS+=(--define=ynn_enable_arm64_neonfp8=false)
+    BAZEL_BUILD_FLAGS+=(--define=ynn_enable_arm64_neonfp8dot4=false)
 fi
 
 if [[ "${bb_full_target}" == *gpu+cuda* ]]; then


### PR DESCRIPTION
Fixes the aarch64-linux Reactant_jll failures on EnzymeAD/Enzyme-JAX#2698: the XNNPACK bump that rides the new XLA adds ynnpack FP8 dot kernels (`arm64_neonfp8dot4_*.cc`) compiled with `-march=armv8.2-a+fp8+fp8dot4` against the ARM FP8 ACLE (`mfloat8x8_t`, `__arm_fpm_init`, `__ARM_FPM_E4M3`) — GCC has that only from 15 on, and the jll toolchain is older, so every aarch64 build dies compiling them.

Disables `ynn_enable_arm64_neonfp8` (+ `fp8dot4`, which defaults from it) for aarch64 targets — same mechanism Reactant.jl's .bazelrc already uses for `ynn_enable_arm64_sme` on macOS. These kernels are runtime-dispatched extras only selected on FP8-capable cores, so nothing regresses on today's hardware.

Harmless on the current (pre-bump) pin: the define simply has no matching `config_setting` consumer before the XNNPACK bump — bazel `--define` values are inert when nothing selects on them.

The rocm and darwin/x86 failures on that run are addressed by EnzymeAD/Reactant.jl#3178 and EnzymeAD/Reactant.jl#3177 respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

[skip ci]