### PR TITLE
rocm: point the hipcc toolchain environment at the TheRock dist

### DIFF
--- a/R/Reactant/build_tarballs.jl
+++ b/R/Reactant/build_tarballs.jl
@@ -335,6 +335,14 @@ if [[ "${bb_full_target}" == *gpu+rocm* ]]; then
         --action_env=ROCM_PATH=$ROCM_PATH
         --repo_env=ROCM_PATH=$ROCM_PATH
 
+        # hipcc_configure (rules_ml_toolchain) assembles the environment it
+        # re-exports to compile actions from these variables; point them at
+        # the TheRock dist prepared above so hipcc finds its clang and the
+        # device bitcode, and so the toolchain's env_entry values are the
+        # real paths rather than empty.
+        --repo_env=HIP_CLANG_PATH=$ROCM_PATH/lib/llvm/bin
+        --repo_env=DEVICE_LIB_PATH=$ROCM_PATH/amdgcn/bitcode
+
         # anything before 942 hits a 128-bit error
         --action_env=TF_ROCM_AMDGPU_TARGETS="gfx942,gfx1030,gfx1100,gfx1200,gfx1201"
 


### PR DESCRIPTION
Fixes the Reactant_jll rocm failure on EnzymeAD/Enzyme-JAX#2698 (`value parameter of env_entry must be a nonempty string`): the new XLA hipcc toolchain feature re-exports `hipcc_config().hipcc_env` to compile actions unconditionally, and with none of the HIPCC environment variables visible to `hipcc_configure` the value is empty. Rather than patching XLA to tolerate the empty value, set `HIP_CLANG_PATH` and `DEVICE_LIB_PATH` as `--repo_env`, pointing at the TheRock dist this script already prepares — which is also simply where hipcc's clang and device bitcode actually live.

**Verified locally against the 2698 pin** (TheRock 7.10 dist, fresh `@config_rocm_hipcc` fetch):
- without the variables: `bazel build --nobuild --config=rocm ... @local_config_rocm//crosstool:cc-compiler-local-config` fails exactly as in CI;
- with them: generated `hipcc_env = "HIP_CLANG_PATH=... DEVICE_LIB_PATH=..."` and the toolchain target analyzes clean (`Build completed successfully`).

Side note: `hipcc_configure`'s `repository_rule` doesn't declare these variables in `environ`, so changing them doesn't invalidate an already-fetched repo (irrelevant for CI's fresh fetches; upstream fix proposed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

[skipci]