### PR TITLE
[CI] Make `ENZYMEAD_BOT_ID` and `ENZYMEAD_BOT_PRIVATE_KEY` not required

### DIFF
--- a/.github/workflows/build-reactant-reusable.yml
+++ b/.github/workflows/build-reactant-reusable.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     secrets:
       ENZYMEAD_BOT_ID:
-        required: true
+        required: false
       ENZYMEAD_BOT_PRIVATE_KEY:
-        required: true
+        required: false
     inputs:
       julia_version:
         description: 'Julia version'


### PR DESCRIPTION
This is to allow PRs from forks to run, as suggested 5 months ago at https://github.com/EnzymeAD/ReactantBuilder/pull/147#issuecomment-4147689585.